### PR TITLE
(KUR-33) Thunder Liveblogging: Paragragh integration

### DIFF
--- a/modules/liveblog_paragraphs/config/install/core.entity_form_display.liveblog_post.liveblog_post.default.yml
+++ b/modules/liveblog_paragraphs/config/install/core.entity_form_display.liveblog_post.liveblog_post.default.yml
@@ -1,0 +1,81 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.liveblog_post.liveblog_post.field_embed_media
+  module:
+    - link
+    - liveblog
+    - paragraphs
+    - text
+id: liveblog_post.liveblog_post.default
+targetEntityType: liveblog_post
+bundle: liveblog_post
+mode: default
+content:
+  body:
+    type: text_textarea
+    weight: 2
+    settings:
+      rows: 3
+      placeholder: ''
+    third_party_settings: {  }
+  field_embed_media:
+    type: entity_reference_paragraphs
+    weight: 1
+    settings:
+      title: Media
+      title_plural: Medias
+      edit_mode: open
+      add_mode: dropdown
+      form_display_mode: default
+    third_party_settings: {  }
+  highlight:
+    type: options_select
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+  liveblog:
+    type: entity_reference_autocomplete
+    weight: 7
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  location:
+    type: string_textfield
+    weight: 5
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  source:
+    type: link_default
+    weight: 4
+    settings:
+      placeholder_url: ''
+      placeholder_title: ''
+    third_party_settings: {  }
+  status:
+    settings:
+      display_label: true
+    weight: 8
+    third_party_settings: {  }
+    type: boolean_checkbox
+  title:
+    type: string_textfield
+    weight: 0
+    settings:
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+  uid:
+    type: entity_reference_autocomplete
+    weight: 6
+    settings:
+      match_operator: CONTAINS
+      size: 60
+      placeholder: ''
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/liveblog_paragraphs/config/install/core.entity_view_display.liveblog_post.liveblog_post.default.yml
+++ b/modules/liveblog_paragraphs/config/install/core.entity_view_display.liveblog_post.liveblog_post.default.yml
@@ -1,0 +1,105 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.field.liveblog_post.liveblog_post.field_embed_media
+  module:
+    - entity_reference_revisions
+    - link
+    - liveblog
+    - options
+    - simple_gmap
+    - text
+    - user
+id: liveblog_post.liveblog_post.default
+targetEntityType: liveblog_post
+bundle: liveblog_post
+mode: default
+content:
+  body:
+    type: text_default
+    weight: 6
+    label: hidden
+    settings: {  }
+    third_party_settings: {  }
+  changed:
+    label: hidden
+    type: timestamp
+    weight: 4
+    settings:
+      date_format: medium
+      custom_date_format: ''
+      timezone: ''
+    third_party_settings: {  }
+  created:
+    label: hidden
+    type: timestamp
+    weight: 3
+    settings:
+      date_format: medium
+      custom_date_format: ''
+      timezone: ''
+    third_party_settings: {  }
+  field_embed_media:
+    type: entity_reference_revisions_entity_view
+    weight: 5
+    label: above
+    settings:
+      view_mode: default
+      link: ''
+    third_party_settings: {  }
+  highlight:
+    label: hidden
+    weight: 0
+    settings: {  }
+    third_party_settings: {  }
+    type: list_default
+  liveblog:
+    label: inline
+    weight: 9
+    type: entity_reference_label
+    settings:
+      link: true
+    third_party_settings: {  }
+  location:
+    type: simple_gmap
+    weight: 8
+    label: hidden
+    settings:
+      include_map: '1'
+      include_static_map: '0'
+      include_link: '0'
+      include_text: '0'
+      iframe_height: '200'
+      iframe_width: '200'
+      zoom_level: '14'
+      information_bubble: '1'
+      link_text: 'View larger map'
+      map_type: m
+      langcode: en
+    third_party_settings: {  }
+  source:
+    label: inline
+    type: link
+    weight: 7
+    settings:
+      trim_length: 80
+      url_only: false
+      url_plain: false
+      rel: ''
+      target: ''
+    third_party_settings: {  }
+  title:
+    label: hidden
+    type: string
+    weight: 1
+    settings:
+      link_to_entity: false
+    third_party_settings: {  }
+  uid:
+    label: hidden
+    type: author
+    weight: 2
+    settings: {  }
+    third_party_settings: {  }
+hidden: {  }

--- a/modules/liveblog_paragraphs/config/install/field.field.liveblog_post.liveblog_post.field_embed_media.yml
+++ b/modules/liveblog_paragraphs/config/install/field.field.liveblog_post.liveblog_post.field_embed_media.yml
@@ -1,0 +1,49 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.liveblog_post.field_embed_media
+    - paragraphs.paragraphs_type.instagram
+    - paragraphs.paragraphs_type.twitter
+  module:
+    - entity_reference_revisions
+    - liveblog
+id: liveblog_post.liveblog_post.field_embed_media
+field_name: field_embed_media
+entity_type: liveblog_post
+bundle: liveblog_post
+label: 'Embed media'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  handler: 'default:paragraph'
+  handler_settings:
+    target_bundles:
+      instagram: instagram
+      twitter: twitter
+    target_bundles_drag_drop:
+      gallery:
+        weight: 8
+        enabled: false
+      instagram:
+        enabled: true
+        weight: 9
+      link:
+        weight: 10
+        enabled: false
+      media:
+        weight: 11
+        enabled: false
+      quote:
+        weight: 12
+        enabled: false
+      text:
+        weight: 13
+        enabled: false
+      twitter:
+        enabled: true
+        weight: 14
+field_type: entity_reference_revisions

--- a/modules/liveblog_paragraphs/config/install/field.storage.liveblog_post.field_embed_media.yml
+++ b/modules/liveblog_paragraphs/config/install/field.storage.liveblog_post.field_embed_media.yml
@@ -1,0 +1,20 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - entity_reference_revisions
+    - liveblog
+    - paragraphs
+id: liveblog_post.field_embed_media
+field_name: field_embed_media
+entity_type: liveblog_post
+type: entity_reference_revisions
+settings:
+  target_type: paragraph
+module: entity_reference_revisions
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/modules/liveblog_paragraphs/liveblog_paragraphs.info.yml
+++ b/modules/liveblog_paragraphs/liveblog_paragraphs.info.yml
@@ -1,0 +1,15 @@
+name: 'Liveblog paragraphs'
+type: module
+core: 8.x
+dependencies:
+  - entity_reference_revisions
+  - field
+  - link
+  - liveblog
+  - options
+  - paragraphs
+  - simple_gmap
+  - text
+  - thunder
+  - thunder_paragraphs
+  - user


### PR DESCRIPTION
Integration with paragraph (optional module):
* Paragraph  integration as an additional module // see existing paragraph integrations in Thunder.
* The module adds an additional field for embedding media links (twitter, youtube, etc.) to liveblog posts.
* Only 1 value should be possible: either twitter or youtube, or etc.