### PR TITLE
KUR-44 Implement notifications via the pusher API

### DIFF
--- a/liveblog.links.menu.yml
+++ b/liveblog.links.menu.yml
@@ -1,7 +1,13 @@
 # Define the menu links for this module
 
 liveblog_post.admin.structure.settings:
-  title: Liveblog Posts
+  title: 'Liveblog Posts'
   description: 'Configure Liveblog Post entity'
   route_name:  liveblog_post.liveblog_post_settings
   parent: system.admin_structure
+
+liveblog.notification_channel_settings:
+  title: 'Liveblog Notification Channel'
+  description: 'Configure notification channel settings'
+  parent: system.admin_config_services
+  route_name: liveblog.notification_channel_settings

--- a/liveblog.module
+++ b/liveblog.module
@@ -7,6 +7,10 @@
 
 use Drupal\Core\Entity\Display\EntityViewDisplayInterface;
 use Drupal\node\Entity\Node;
+use Drupal\taxonomy\Entity\Term;
+use Drupal\Core\Field\FieldStorageDefinitionInterface;
+use Drupal\Core\Entity\FieldableEntityInterface;
+use \Drupal\Component\Utility\Html;
 
 /**
  * Implements hook_entity_extra_field_info().
@@ -73,4 +77,42 @@ function template_preprocess_liveblog_posts(&$variables) {
     $views_content = views_embed_view('liveblog_posts', 'liveblog_posts_archive', $node->id());
   }
   $variables['posts'] = \Drupal::service('renderer')->render($views_content);
+}
+
+/**
+ * Gets highlight options from the liveblog.
+ *
+ * @param \Drupal\Core\Field\FieldStorageDefinitionInterface $definition
+ *   The field storage definition.
+ * @param \Drupal\Core\Entity\FieldableEntityInterface|NULL $entity
+ *   The entity.
+ * @param null $cacheable
+ *   If $cacheable is FALSE, then the allowed values are not statically
+ *   cached. See options_test_dynamic_values_callback() for an example of
+ *   generating dynamic and uncached values.
+ *
+ * @return string[]
+ *   Highlight options.
+ *
+ * @see options_allowed_values()
+ */
+function liveblog_post_get_highlight_options(FieldStorageDefinitionInterface $definition, FieldableEntityInterface $entity = NULL, &$cacheable = NULL) {
+  $options = [];
+
+  // @todo: get terms from liveblog. hook_entity_prepare_form
+  $ids = \Drupal::entityQuery('taxonomy_term')
+    ->condition('vid', 'highlights')
+    ->execute();
+  if (!empty($ids)) {
+    $terms = Term::loadMultiple($ids);
+    foreach ($terms as $term) {
+      $name = $term->name->value;
+      // Convert term name to a machine name, which will be used as a CSS
+      // class in templates.
+      $key = strtolower(Html::cleanCssIdentifier($name));
+      $options[$key] = $name;
+    }
+  }
+
+  return $options;
 }

--- a/liveblog.permissions.yml
+++ b/liveblog.permissions.yml
@@ -8,3 +8,5 @@
   title: Edit liveblog posts
 'administer liveblog_post entity':
   title: Administer liveblog posts
+'administer liveblog settings':
+  title: Administer liveblog settings

--- a/liveblog.routing.yml
+++ b/liveblog.routing.yml
@@ -40,9 +40,17 @@ entity.liveblog_post.delete_form:
     _entity_access: 'liveblog_post.delete'
 
 liveblog_post.liveblog_post_settings:
-  path: 'admin/structure/liveblog_post_settings'
+  path: '/admin/structure/liveblog_post_settings'
   defaults:
     _form: '\Drupal\liveblog\Form\LiveblogPostSettingsForm'
     _title: 'Liveblog Post Settings'
   requirements:
     _permission: 'administer liveblog_post entity'
+
+liveblog.notification_channel_settings:
+  path: '/admin/config/services/liveblog-notification-channel'
+  defaults:
+    _form:  '\Drupal\liveblog\Form\NotificationChannelSettingsForm'
+    _title: 'Liveblog notification channel settings'
+  requirements:
+    _permission: 'administer liveblog settings'

--- a/liveblog.services.yml
+++ b/liveblog.services.yml
@@ -1,4 +1,4 @@
 services:
   plugin.manager.liveblog.notification_channel:
     class: Drupal\liveblog\NotificationChannel\NotificationChannelManager
-    parent: default_plugin_manager
+    arguments: ['@container.namespaces', '@cache.discovery', '@module_handler', '@config.factory']

--- a/liveblog.services.yml
+++ b/liveblog.services.yml
@@ -1,0 +1,4 @@
+services:
+  plugin.manager.liveblog.notification_channel:
+    class: Drupal\liveblog\NotificationChannel\NotificationChannelManager
+    parent: default_plugin_manager

--- a/modules/liveblog_pusher/liveblog_pusher.info.yml
+++ b/modules/liveblog_pusher/liveblog_pusher.info.yml
@@ -1,0 +1,6 @@
+name: Liveblog Pusher
+description: Provides Liveblog Notification Channel for Pusher.com
+type: module
+core: 8.x
+dependencies:
+  - liveblog

--- a/modules/liveblog_pusher/liveblog_pusher.services.yml
+++ b/modules/liveblog_pusher/liveblog_pusher.services.yml
@@ -1,0 +1,4 @@
+services:
+  liveblog_pusher.notification_channel.log:
+    class: Drupal\liveblog_pusher\PusherLogger
+    arguments: ['@logger.factory']

--- a/modules/liveblog_pusher/src/Plugin/LiveblogNotificationChannel/Pusher.php
+++ b/modules/liveblog_pusher/src/Plugin/LiveblogNotificationChannel/Pusher.php
@@ -1,0 +1,57 @@
+<?php
+
+namespace Drupal\liveblog_pusher\Plugin\LiveblogNotificationChannel;
+
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\liveblog\NotificationChannel\NotificationChannelPluginBase;
+
+/**
+ * Pusher.com notification channel.
+ *
+ * @LiveblogNotificationChannel(
+ *   id = "liveblog_pusher",
+ *   label = @Translation("Pusher.com"),
+ *   description = @Translation("Pusher.com notification channel."),
+ * )
+ */
+class Pusher extends NotificationChannelPluginBase {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    $form = parent::buildConfigurationForm($form, $form_state);
+    $form['app_id'] = [
+      '#type' => 'textfield',
+      '#title' => t('App ID'),
+      '#required' => TRUE,
+      '#default_value' => !empty($this->configuration['app_id']) ? $this->configuration['app_id'] : '',
+      '#description' => t('Please enter your Pusher App ID.'),
+    ];
+    $form['key'] = [
+      '#type' => 'textfield',
+      '#title' => t('Username'),
+      '#required' => TRUE,
+      '#default_value' => !empty($this->configuration['key']) ? $this->configuration['key']: '',
+      '#description' => t('Please enter your Pusher key.'),
+    ];
+    $form['secret'] = [
+      '#type' => 'textfield',
+      '#title' => t('Secret'),
+      '#required' => TRUE,
+      '#default_value' => !empty($this->configuration['secret']) ? $this->configuration['secret'] : '',
+      '#description' => t('Please enter your Pusher secret.'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+    parent::validateConfigurationForm($form, $form_state);
+    // @todo: require dependency on pusher library.
+  }
+
+}

--- a/modules/liveblog_pusher/src/Plugin/LiveblogNotificationChannel/PusherNotificationChannel.php
+++ b/modules/liveblog_pusher/src/Plugin/LiveblogNotificationChannel/PusherNotificationChannel.php
@@ -14,7 +14,7 @@ use Drupal\liveblog\NotificationChannel\NotificationChannelPluginBase;
  *   description = @Translation("Pusher.com notification channel."),
  * )
  */
-class Pusher extends NotificationChannelPluginBase {
+class PusherNotificationChannel extends NotificationChannelPluginBase {
 
   /**
    * {@inheritdoc}
@@ -51,7 +51,10 @@ class Pusher extends NotificationChannelPluginBase {
    */
   public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
     parent::validateConfigurationForm($form, $form_state);
-    // @todo: require dependency on pusher library.
+    // Check the required dependency on the Pusher library.
+    if (!class_exists('\Pusher')) {
+      $form_state->setErrorByName('plugin', t('The "\Pusher" class was not found. Please make sure you have included the <a href="https://github.com/pusher/pusher-http-php">Pusher PHP Library</a>.'));
+    }
   }
 
 }

--- a/modules/liveblog_pusher/src/Plugin/LiveblogNotificationChannel/PusherNotificationChannel.php
+++ b/modules/liveblog_pusher/src/Plugin/LiveblogNotificationChannel/PusherNotificationChannel.php
@@ -95,7 +95,8 @@ class PusherNotificationChannel extends NotificationChannelPluginBase {
 
     $channel = "liveblog-{$liveblogPost->id()}";
 
-    $data['message'] = 'hello world';
+    $rendered_entity = render($this->entityTypeManager->getViewBuilder('liveblog_post')->view($liveblogPost));
+    $data['rendered_entity'] = $rendered_entity;
 
     // Trigger an event by providing event name and payload.
     $response = $client->trigger($channel, $event, $data);

--- a/modules/liveblog_pusher/src/Plugin/LiveblogNotificationChannel/PusherNotificationChannel.php
+++ b/modules/liveblog_pusher/src/Plugin/LiveblogNotificationChannel/PusherNotificationChannel.php
@@ -95,8 +95,9 @@ class PusherNotificationChannel extends NotificationChannelPluginBase {
 
     $channel = "liveblog-{$liveblogPost->id()}";
 
-    $rendered_entity = render($this->entityTypeManager->getViewBuilder('liveblog_post')->view($liveblogPost));
-    $data['rendered_entity'] = $rendered_entity;
+    $rendered_entity = $this->entityTypeManager->getViewBuilder('liveblog_post')->view($liveblogPost);
+    $output = render($rendered_entity);
+    $data['rendered_entity'] = $output;
 
     // Trigger an event by providing event name and payload.
     $response = $client->trigger($channel, $event, $data);

--- a/modules/liveblog_pusher/src/Plugin/LiveblogNotificationChannel/PusherNotificationChannel.php
+++ b/modules/liveblog_pusher/src/Plugin/LiveblogNotificationChannel/PusherNotificationChannel.php
@@ -2,9 +2,13 @@
 
 namespace Drupal\liveblog_pusher\Plugin\LiveblogNotificationChannel;
 
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Drupal\liveblog\Entity\LiveblogPost;
 use Drupal\liveblog\NotificationChannel\NotificationChannelPluginBase;
+use Drupal\liveblog_pusher\PusherLoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Pusher.com notification channel.
@@ -17,12 +21,54 @@ use Drupal\liveblog\NotificationChannel\NotificationChannelPluginBase;
  */
 class PusherNotificationChannel extends NotificationChannelPluginBase {
 
+
+  /**
+   * The entity type manager.
+   *
+   * @var \Drupal\liveblog_pusher\PusherLoggerInterface
+   */
+  protected $logger;
+
   /**
    * The pusher client.
    *
    * @var \Pusher
    */
   protected $client;
+
+
+  /**
+   * Constructs an EntityForm object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\liveblog_pusher\PusherLoggerInterface $logger
+   *   The logger.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager, PusherLoggerInterface $logger) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $config_factory, $entity_type_manager);
+    $this->logger = $logger;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory'),
+      $container->get('entity_type.manager'),
+      $container->get('liveblog_pusher.notification_channel.log')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -73,7 +119,6 @@ class PusherNotificationChannel extends NotificationChannelPluginBase {
    */
   public function getClient() {
     if (!$this->client) {
-      // @todo Add logger.
       $options = array(
         'encrypted' => true
       );
@@ -83,6 +128,7 @@ class PusherNotificationChannel extends NotificationChannelPluginBase {
         $this->getConfigurationValue('app_id'),
         $options
       );
+      $this->client->set_logger($this->logger);
     }
     return $this->client;
   }
@@ -101,7 +147,11 @@ class PusherNotificationChannel extends NotificationChannelPluginBase {
 
     // Trigger an event by providing event name and payload.
     $response = $client->trigger($channel, $event, $data);
-    // @todo: Log response if there is an error.
+
+    if (!$response) {
+      // Log response if there is an error.
+      $this->logger->saveLog('error');
+    }
   }
 
 }

--- a/modules/liveblog_pusher/src/Plugin/LiveblogNotificationChannel/PusherNotificationChannel.php
+++ b/modules/liveblog_pusher/src/Plugin/LiveblogNotificationChannel/PusherNotificationChannel.php
@@ -94,7 +94,7 @@ class PusherNotificationChannel extends NotificationChannelPluginBase {
     ];
     $form['key'] = [
       '#type' => 'textfield',
-      '#title' => t('Username'),
+      '#title' => t('Key'),
       '#required' => TRUE,
       '#default_value' => !empty($this->configuration['key']) ? $this->configuration['key']: '',
       '#description' => t('Please enter your Pusher key.'),

--- a/modules/liveblog_pusher/src/PusherLogger.php
+++ b/modules/liveblog_pusher/src/PusherLogger.php
@@ -1,0 +1,74 @@
+<?php
+
+namespace Drupal\liveblog_pusher;
+
+/**
+ * Logger class for Pusher notifications channel.
+ */
+class PusherLogger implements PusherLoggerInterface {
+
+  /**
+   * A logger instance.
+   *
+   * @var \Psr\Log\LoggerInterface
+   */
+  protected $logger;
+
+  /**
+   * The collected log messages.
+   *
+   * @var string[]
+   */
+  protected $messages;
+
+  /**
+   * PusherLogger constructor.
+   *
+   * @param \Psr\Log\LoggerInterface $logger_factory
+   *   The logger factory.
+   */
+  public function __construct($logger_factory) {
+    $this->logger = $logger_factory->get('liveblog_pusher');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function log($message) {
+    $this->messages[] = $message;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getMessages() {
+    return $this->messages;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function saveLog($type = 'notice') {
+    $log = implode('<br>', $this->messages);
+    switch ($type) {
+      case 'info':
+        $log = 'Pusher request log:<br>' . $log;
+        $this->logger->info($log);
+        break;
+      case 'warning':
+        $log = 'Pusher request log:<br>' . $log;
+        $this->logger->warning($log);
+        break;
+      case 'error':
+        $log = 'Failed to send a message to Pusher. See the request log:<br>' . $log;
+        $this->logger->error($log);
+        break;
+      case 'notice':
+      default:
+        $log = 'Pusher request log:<br>' . $log;
+        $this->logger->notice($log);
+        break;
+    }
+  }
+
+}

--- a/modules/liveblog_pusher/src/PusherLoggerInterface.php
+++ b/modules/liveblog_pusher/src/PusherLoggerInterface.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace Drupal\liveblog_pusher;
+
+interface PusherLoggerInterface {
+
+  /**
+   * Logs a message.
+   *
+   * @param string $message
+   *   The message text.
+   */
+  public function log($message);
+
+  /**
+   * Returns collected log messages.
+   *
+   * @return string[]
+   *   The collected log messages.
+   */
+  public function getMessages();
+
+  /**
+   * Saves the log.
+   *
+   * @param string $type
+   *   The log type. E.g.: 'info', 'notice', 'error', 'warning'.
+   */
+  public function saveLog($type = 'notice');
+
+}

--- a/src/Annotation/LiveblogNotificationChannel.php
+++ b/src/Annotation/LiveblogNotificationChannel.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace Drupal\liveblog\Annotation;
+
+use Drupal\Component\Annotation\Plugin;
+
+/**
+ * Defines an Liveblog Notification Channel annotation object.
+ *
+ * Plugin Namespace: Plugin\LiveblogNotificationChannel
+ *
+ * @see plugin_api
+ *
+ * @Annotation
+ */
+class LiveblogNotificationChannel extends Plugin {
+
+  /**
+   * The plugin ID.
+   *
+   * @var string
+   */
+  public $id;
+
+  /**
+   * The human-readable name of the plugin.
+   *
+   * @ingroup plugin_translatable
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   */
+  public $title;
+
+  /**
+   * The description of the plugin.
+   *
+   * @ingroup plugin_translatable
+   *
+   * @var \Drupal\Core\Annotation\Translation
+   */
+  public $description;
+
+}

--- a/src/Entity/LiveblogPost.php
+++ b/src/Entity/LiveblogPost.php
@@ -216,6 +216,8 @@ class LiveblogPost extends ContentEntityBase implements LiveblogPostInterface {
     $fields['highlight'] = BaseFieldDefinition::create('list_string')
       ->setLabel(t('Highlight'))
       ->setDescription(t('Adds the possibility to mark a post as a highlight.'))
+      // We can not make this callback as a static method of the LiveblogPost
+      // class to support older PHP versions.
       ->setSetting('allowed_values_function','liveblog_post_get_highlight_options')
       ->setDefaultValue('')
       ->setDisplayOptions('form', [

--- a/src/Entity/LiveblogPost.php
+++ b/src/Entity/LiveblogPost.php
@@ -119,18 +119,18 @@ class LiveblogPost extends ContentEntityBase implements LiveblogPostInterface {
    * @return \Drupal\node\NodeInterface
    *   The related liveblog node.
    */
-  public function getLiveblog() {
-    return $this->get('liveblog')->entity;
+  public function getTitle() {
+    return $this->get('title')->value;
   }
 
   /**
-   * Returns the related liveblog node ID.
+   * Returns the related liveblog node.
    *
-   * @return int
-   *   The related liveblog node ID.
+   * @return \Drupal\node\NodeInterface
+   *   The related liveblog node.
    */
-  public function getLiveblogId() {
-    return $this->get('liveblog')->target_id;
+  public function getLiveblog() {
+    return $this->get('liveblog')->entity;
   }
 
   /**
@@ -144,6 +144,39 @@ class LiveblogPost extends ContentEntityBase implements LiveblogPostInterface {
   public function setLiveblog(NodeInterface $node) {
     $this->set('liveblog', $node->id());
     return $this;
+  }
+
+  /**
+   * Returns the related liveblog author.
+   *
+   * @return \Drupal\user\UserInterface
+   *   The related liveblog author.
+   */
+  public function getAuthor() {
+    return $this->get('uid')->entity;
+  }
+
+  /**
+   * Sets the related liveblog author.
+   *
+   * @param \Drupal\user\UserInterface $user
+   *   The related liveblog author.
+   *
+   * @return $this
+   */
+  public function setAuthor(UserInterface $user) {
+    $this->set('uid', $user->id());
+    return $this;
+  }
+
+  /**
+   * Returns the related liveblog node ID.
+   *
+   * @return int
+   *   The related liveblog node ID.
+   */
+  public function getLiveblogId() {
+    return $this->get('liveblog')->target_id;
   }
 
   /**

--- a/src/Entity/LiveblogPost.php
+++ b/src/Entity/LiveblogPost.php
@@ -254,7 +254,8 @@ class LiveblogPost extends ContentEntityBase implements LiveblogPostInterface {
     $fields['highlight'] = BaseFieldDefinition::create('list_string')
       ->setLabel(t('Highlight'))
       ->setDescription(t('Adds the possibility to mark a post as a highlight.'))
-      ->setSetting('allowed_values_function', __CLASS__ . '::getHighlightOptions')
+      //->setSetting('allowed_values_function', __CLASS__ . '::getHighlightOptions')
+      ->setSetting('allowed_values_function','liveblog_post_get_highlight_options')
       ->setDefaultValue('')
       ->setDisplayOptions('form', [
         'type' => 'select',

--- a/src/Entity/LiveblogPost.php
+++ b/src/Entity/LiveblogPost.php
@@ -147,44 +147,6 @@ class LiveblogPost extends ContentEntityBase implements LiveblogPostInterface {
   }
 
   /**
-   * Gets highlight options from the liveblog.
-   *
-   * @param \Drupal\Core\Field\FieldStorageDefinitionInterface $definition
-   *   The field storage definition.
-   * @param \Drupal\Core\Entity\FieldableEntityInterface|NULL $entity
-   *   The entity.
-   * @param null $cacheable
-   *   If $cacheable is FALSE, then the allowed values are not statically
-   *   cached. See options_test_dynamic_values_callback() for an example of
-   *   generating dynamic and uncached values.
-   *
-   * @return string[]
-   *   Highlight options.
-   *
-   * @see options_allowed_values()
-   */
-  public static function getHighlightOptions(FieldStorageDefinitionInterface $definition, FieldableEntityInterface $entity = NULL, &$cacheable = NULL) {
-    $options = [];
-
-    // @todo: get terms from liveblog. hook_entity_prepare_form
-    $ids = \Drupal::entityQuery('taxonomy_term')
-      ->condition('vid', self::LIVEBLOG_POSTS_HIGHLIGHTS_VID)
-      ->execute();
-    if (!empty($ids)) {
-      $terms = Term::loadMultiple($ids);
-      foreach ($terms as $term) {
-        $name = $term->name->value;
-        // Convert term name to a machine name, which will be used as a CSS
-        // class in templates.
-        $key = strtolower(Html::cleanCssIdentifier($name));
-        $options[$key] = $name;
-      }
-    }
-
-    return $options;
-  }
-
-  /**
    * {@inheritdoc}
    *
    * Define the field properties here.
@@ -254,7 +216,6 @@ class LiveblogPost extends ContentEntityBase implements LiveblogPostInterface {
     $fields['highlight'] = BaseFieldDefinition::create('list_string')
       ->setLabel(t('Highlight'))
       ->setDescription(t('Adds the possibility to mark a post as a highlight.'))
-      //->setSetting('allowed_values_function', __CLASS__ . '::getHighlightOptions')
       ->setSetting('allowed_values_function','liveblog_post_get_highlight_options')
       ->setDefaultValue('')
       ->setDisplayOptions('form', [

--- a/src/Entity/LiveblogPost.php
+++ b/src/Entity/LiveblogPost.php
@@ -59,6 +59,13 @@ class LiveblogPost extends ContentEntityBase implements LiveblogPostInterface {
   const LIVEBLOG_POSTS_HIGHLIGHTS_VID = 'highlights';
 
   /**
+   * The renderer.
+   *
+   * @var \Drupal\Core\Render\Renderer
+   */
+  protected $renderer;
+
+  /**
    * {@inheritdoc}
    *
    * When a new entity instance is added, set the user_id entity reference to
@@ -177,6 +184,19 @@ class LiveblogPost extends ContentEntityBase implements LiveblogPostInterface {
    */
   public function getLiveblogId() {
     return $this->get('liveblog')->target_id;
+  }
+
+  /**
+   * Returns the render API renderer.
+   *
+   * @return \Drupal\Core\Render\RendererInterface
+   */
+  protected function getRenderer() {
+    if (!isset($this->renderer)) {
+      $this->renderer = \Drupal::service('renderer');
+    }
+
+    return $this->renderer;
   }
 
   /**
@@ -393,6 +413,39 @@ class LiveblogPost extends ContentEntityBase implements LiveblogPostInterface {
       ->setDisplayConfigurable('view', TRUE);
 
     return $fields;
+  }
+
+  /**
+   * Gets payload from the liveblog post entity.
+   *
+   * @todo Currently the liveblog post has 3 different ways of rendering by REST
+   *   services: 1) views for the list of posts 2) default GET endpoint by the
+   *   REST module 3) this method. Would be good to use this method in all the
+   *   3 cases to follow the same structure, because the frontend library
+   *   should rely on this payload structure in all the cases.
+   *
+   * @return array
+   *   The payload array.
+   */
+  public function getPayload() {
+    $rendered_entity = $this->entityTypeManager()->getViewBuilder('liveblog_post')->view($this);
+    $output = $this->getRenderer()->render($rendered_entity);
+
+    $data['id'] = $this->id();
+    $data['uuid'] = $this->uuid();
+    $data['title'] = $this->get('title')->value;
+    $data['liveblog'] = $this->getLiveblog()->id();
+    $data['body__value'] = $this->body->value;
+    $data['highlight'] = $this->highlight->value;
+    $data['location'] = $this->location->value;
+    $data['source__uri'] = $this->source->first() ? $this->source->first()->getUrl()->toString() : NULL;
+    $data['uid'] = $this->getAuthor() ? $this->getAuthor()->getAccountName() : NULL;
+    $data['changed'] = $this->changed->value;
+    $data['created'] = $this->created->value;
+    $data['status'] = $this->status->value;
+    $data['rendered_entity'] = $output;
+
+    return $data;
   }
 
 }

--- a/src/Form/LiveblogPostForm.php
+++ b/src/Form/LiveblogPostForm.php
@@ -36,6 +36,8 @@ class LiveblogPostForm extends ContentEntityForm {
 
     // Redirect to the post's full page.
     $form_state->setRedirect($url->getRouteName(), $url->getRouteParameters());
+
+    // @todo Trigger an notification channel update.
   }
 
 }

--- a/src/Form/LiveblogPostForm.php
+++ b/src/Form/LiveblogPostForm.php
@@ -3,8 +3,10 @@
 namespace Drupal\liveblog\Form;
 
 use Drupal\Core\Entity\ContentEntityForm;
-use Drupal\Core\Language\Language;
+use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Drupal\liveblog\NotificationChannel\NotificationChannelManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Form controller for the liveblog_post entity edit forms.
@@ -12,6 +14,36 @@ use Drupal\Core\Form\FormStateInterface;
  * @ingroup liveblog_post
  */
 class LiveblogPostForm extends ContentEntityForm {
+
+  /**
+   * The notification channel manager.
+   *
+   * @var \Drupal\liveblog\NotificationChannel\NotificationChannelManager
+   */
+  protected $notificationChannelManager;
+
+  /**
+   * Constructs an EntityForm object.
+   *
+   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
+   *   The entity manager.
+   * @param \Drupal\liveblog\NotificationChannel\NotificationChannelManager $notification_channel_manager
+   *   The notification channel service.
+   */
+  public function __construct(EntityManagerInterface $entity_manager, NotificationChannelManager $notification_channel_manager) {
+    parent::__construct($entity_manager);
+    $this->notificationChannelManager = $notification_channel_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity.manager'),
+      $container->get('plugin.manager.liveblog.notification_channel')
+    );
+  }
 
   /**
    * {@inheritdoc}
@@ -31,13 +63,19 @@ class LiveblogPostForm extends ContentEntityForm {
    */
   public function save(array $form, FormStateInterface $form_state) {
     $entity = $this->getEntity();
+
+    $event = $entity->isNew() ? 'created' : 'updated';
+
     $entity->save();
     $url = $entity->toUrl();
 
     // Redirect to the post's full page.
     $form_state->setRedirect($url->getRouteName(), $url->getRouteParameters());
 
-    // @todo Trigger an notification channel update.
+    // Trigger an notification channel message.
+    if ($plugin = $this->notificationChannelManager->createActiveInstance()) {
+      $plugin->triggerLiveblogPostEvent($entity, $event);
+    }
   }
 
 }

--- a/src/Form/NotificationChannelSettingsForm.php
+++ b/src/Form/NotificationChannelSettingsForm.php
@@ -141,7 +141,7 @@ class NotificationChannelSettingsForm extends ConfigFormBase  {
     ];
     $form['actions']['submit'] = [
       '#type' => 'submit',
-      '#value' => $this->t('Submit'),
+      '#value' => $this->t('Save'),
     ];
 
     return $form;

--- a/src/Form/NotificationChannelSettingsForm.php
+++ b/src/Form/NotificationChannelSettingsForm.php
@@ -1,0 +1,170 @@
+<?php
+
+namespace Drupal\liveblog\Form;
+
+use Drupal\Component\Utility\Xss;
+use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Form\ConfigFormBase;
+use Drupal\Core\Form\FormStateInterface;
+use Drupal\liveblog\NotificationChannel\NotificationChannelManager;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Settings form for notification channel.
+ *
+ * @see \Drupal\Core\Form\FormBase
+ */
+class NotificationChannelSettingsForm extends ConfigFormBase  {
+
+  /**
+   * Translator plugin manager.
+   *
+   * @var \Drupal\liveblog\NotificationChannel\NotificationChannelManager
+   */
+  protected $notificationChannelManager;
+
+  /**
+   * Constructs an EntityForm object.
+   *
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   * @param \Drupal\liveblog\NotificationChannel\NotificationChannelManager $notification_channel_manager
+   *   The module handler service.
+   */
+  public function __construct(ConfigFactoryInterface $config_factory, NotificationChannelManager $notification_channel_manager) {
+    parent::__construct($config_factory);
+    $this->notificationChannelManager = $notification_channel_manager;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('config.factory'),
+      $container->get('plugin.manager.liveblog.notification_channel')
+    );
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getFormId() {
+    return 'liveblog_notification_channel_settings_form';
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  protected function getEditableConfigNames() {
+    return [
+      'liveblog.notification_channel.settings',
+    ];
+  }
+
+  /**
+   * Gets notification channel config.
+   *
+   * @return \Drupal\Core\Config\Config|\Drupal\Core\Config\ImmutableConfig
+   *   Notification channel config.
+   */
+  protected function getConfig() {
+    return $this->config('liveblog.notification_channel.settings');
+  }
+
+  /**
+   * Sets notification channel config.
+   *
+   * @param string $name
+   *   The config variable name.
+   * @param string $value
+   *   The config variable value.
+   */
+  protected function setConfig($name, $value) {
+    $config = $this->configFactory()->getEditable('liveblog.notification_channel.settings');
+    $config->set($name, $value)->save();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildForm(array $form, FormStateInterface $form_state) {
+    $config = $this->getConfig();
+
+    $form['plugin_wrapper'] = array(
+      '#type' => 'container',
+      '#prefix' => '<div id="liveblog-plugin-wrapper">',
+      '#suffix' => '</div>',
+    );
+
+    if ($available = $this->notificationChannelManager->getLabels()) {
+      // If the plugin is not set, pick the first available as the default.
+      $plugin_id = $config->get('plugin') ?: key($available);
+      $definition = $this->notificationChannelManager->getDefinition($plugin_id);
+
+      $form['plugin_wrapper']['plugin'] = array(
+        '#type' => 'select',
+        '#title' => t('Provider plugin'),
+        '#limit_validation_errors' => array(array('plugin')),
+        '#executes_submit_callback' => TRUE,
+        '#description' => isset($definition['description']) ? Xss::filter($definition['description']) : '',
+        '#options' => $available,
+        '#default_value' => $plugin_id,
+        '#required' => TRUE,
+        '#ajax' => array(
+          'callback' => array($this, 'ajaxPluginSelect'),
+          'wrapper' => 'liveblog-plugin-wrapper',
+        ),
+      );
+
+      $form['plugin_wrapper']['plugin_settings'] = array(
+        '#type' => 'details',
+        '#title' => t('@plugin plugin settings', array('@plugin' => $definition['label'])),
+        '#tree' => TRUE,
+        '#open' => TRUE,
+      );
+
+      $plugin = $this->notificationChannelManager->createInstance($plugin_id, $config->get('plugin_settings'));
+      $form['plugin_wrapper']['plugin_settings'] += $plugin->buildConfigurationForm($form['plugin_wrapper']['plugin_settings'], $form_state);
+    }
+
+    $form['actions'] = [
+      '#type' => 'actions',
+    ];
+    $form['actions']['submit'] = [
+      '#type' => 'submit',
+      '#value' => $this->t('Submit'),
+    ];
+
+    return $form;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateForm(array &$form, FormStateInterface $form_state) {
+    parent::validateForm($form, $form_state);
+    if (!$plugin = $form_state->getValue('plugin')) {
+      $form_state->setErrorByName('plugin', $this->t('You have to select a liveblog notification channel plugin.'));
+    }
+    $plugin = $this->notificationChannelManager->createInstance($plugin);
+    $plugin->validateConfigurationForm($form, $form_state);
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    $this->setConfig('plugin', $form_state->getValue('plugin'));
+    $this->setConfig('plugin_settings', $form_state->getValue('plugin_settings'));
+    drupal_set_message(t('Liveblog notification settings have been updated.'));
+  }
+
+  /**
+   * Ajax callback for loading the plugin settings form for the selected one.
+   */
+  public static function ajaxPluginSelect(array $form, FormStateInterface $form_state) {
+    return $form['plugin_wrapper'];
+  }
+
+}

--- a/src/Form/NotificationChannelSettingsForm.php
+++ b/src/Form/NotificationChannelSettingsForm.php
@@ -69,7 +69,7 @@ class NotificationChannelSettingsForm extends ConfigFormBase  {
    *   Notification channel config.
    */
   protected function getConfig() {
-    return $this->config('liveblog.notification_channel.settings');
+    return $this->config('liveblog.notification_channel');
   }
 
   /**
@@ -81,7 +81,7 @@ class NotificationChannelSettingsForm extends ConfigFormBase  {
    *   The config variable value.
    */
   protected function setConfig($name, $value) {
-    $config = $this->configFactory()->getEditable('liveblog.notification_channel.settings');
+    $config = $this->configFactory()->getEditable('liveblog.notification_channel');
     $config->set($name, $value)->save();
   }
 
@@ -124,7 +124,7 @@ class NotificationChannelSettingsForm extends ConfigFormBase  {
         '#open' => TRUE,
       );
 
-      $plugin = $this->notificationChannelManager->createInstance($plugin_id, $config->get('plugin_settings'));
+      $plugin = $this->notificationChannelManager->createInstance($plugin_id);
       if ($plugin_form = $plugin->buildConfigurationForm($form['plugin_wrapper']['plugin_settings'], $form_state)) {
         $form['plugin_wrapper']['plugin_settings'] += $plugin_form;
       }
@@ -164,7 +164,6 @@ class NotificationChannelSettingsForm extends ConfigFormBase  {
    */
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->setConfig('plugin', $form_state->getValue('plugin'));
-    $this->setConfig('plugin_settings', $form_state->getValue('plugin_settings'));
 
     $plugin = $form_state->getValue('plugin');
     $plugin = $this->notificationChannelManager->createInstance($plugin);

--- a/src/Form/NotificationChannelSettingsForm.php
+++ b/src/Form/NotificationChannelSettingsForm.php
@@ -91,38 +91,38 @@ class NotificationChannelSettingsForm extends ConfigFormBase  {
   public function buildForm(array $form, FormStateInterface $form_state) {
     $config = $this->getConfig();
 
-    $form['plugin_wrapper'] = array(
+    $form['plugin_wrapper'] = [
       '#type' => 'container',
       '#prefix' => '<div id="liveblog-plugin-wrapper">',
       '#suffix' => '</div>',
-    );
+    ];
 
     if ($available = $this->notificationChannelManager->getLabels()) {
       // If the plugin is not set, pick the first available as the default.
       $plugin_id = $config->get('plugin') ?: key($available);
       $definition = $this->notificationChannelManager->getDefinition($plugin_id);
 
-      $form['plugin_wrapper']['plugin'] = array(
+      $form['plugin_wrapper']['plugin'] = [
         '#type' => 'select',
         '#title' => t('Provider plugin'),
-        '#limit_validation_errors' => array(array('plugin')),
+        '#limit_validation_errors' => [['plugin']],
         '#executes_submit_callback' => TRUE,
         '#description' => isset($definition['description']) ? Xss::filter($definition['description']) : '',
         '#options' => $available,
         '#default_value' => $plugin_id,
         '#required' => TRUE,
-        '#ajax' => array(
-          'callback' => array($this, 'ajaxPluginSelect'),
+        '#ajax' => [
+          'callback' => [$this, 'ajaxPluginSelect'],
           'wrapper' => 'liveblog-plugin-wrapper',
-        ),
-      );
+        ],
+      ];
 
-      $form['plugin_wrapper']['plugin_settings'] = array(
+      $form['plugin_wrapper']['plugin_settings'] = [
         '#type' => 'details',
-        '#title' => t('@plugin plugin settings', array('@plugin' => $definition['label'])),
+        '#title' => t('@plugin plugin settings', ['@plugin' => $definition['label']]),
         '#tree' => TRUE,
         '#open' => TRUE,
-      );
+      ];
 
       $plugin = $this->notificationChannelManager->createInstance($plugin_id);
       if ($plugin_form = $plugin->buildConfigurationForm($form['plugin_wrapper']['plugin_settings'], $form_state)) {

--- a/src/Form/NotificationChannelSettingsForm.php
+++ b/src/Form/NotificationChannelSettingsForm.php
@@ -17,7 +17,7 @@ use Symfony\Component\DependencyInjection\ContainerInterface;
 class NotificationChannelSettingsForm extends ConfigFormBase  {
 
   /**
-   * Translator plugin manager.
+   * The notification channel manager.
    *
    * @var \Drupal\liveblog\NotificationChannel\NotificationChannelManager
    */
@@ -29,7 +29,7 @@ class NotificationChannelSettingsForm extends ConfigFormBase  {
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
    * @param \Drupal\liveblog\NotificationChannel\NotificationChannelManager $notification_channel_manager
-   *   The module handler service.
+   *   The notification channel service.
    */
   public function __construct(ConfigFactoryInterface $config_factory, NotificationChannelManager $notification_channel_manager) {
     parent::__construct($config_factory);

--- a/src/Form/NotificationChannelSettingsForm.php
+++ b/src/Form/NotificationChannelSettingsForm.php
@@ -125,7 +125,15 @@ class NotificationChannelSettingsForm extends ConfigFormBase  {
       );
 
       $plugin = $this->notificationChannelManager->createInstance($plugin_id, $config->get('plugin_settings'));
-      $form['plugin_wrapper']['plugin_settings'] += $plugin->buildConfigurationForm($form['plugin_wrapper']['plugin_settings'], $form_state);
+      if ($plugin_form = $plugin->buildConfigurationForm($form['plugin_wrapper']['plugin_settings'], $form_state)) {
+        $form['plugin_wrapper']['plugin_settings'] += $plugin_form;
+      }
+      else {
+        $form['plugin_wrapper']['plugin_settings']['no_settings'] = [
+          '#type' => 'item',
+          '#markup' => t('The plugin does not provide any settings.'),
+        ];
+      }
     }
 
     $form['actions'] = [
@@ -157,6 +165,11 @@ class NotificationChannelSettingsForm extends ConfigFormBase  {
   public function submitForm(array &$form, FormStateInterface $form_state) {
     $this->setConfig('plugin', $form_state->getValue('plugin'));
     $this->setConfig('plugin_settings', $form_state->getValue('plugin_settings'));
+
+    $plugin = $form_state->getValue('plugin');
+    $plugin = $this->notificationChannelManager->createInstance($plugin);
+    $plugin->submitConfigurationForm($form, $form_state);
+
     drupal_set_message(t('Liveblog notification settings have been updated.'));
   }
 

--- a/src/Form/NotificationChannelSettingsForm.php
+++ b/src/Form/NotificationChannelSettingsForm.php
@@ -58,7 +58,7 @@ class NotificationChannelSettingsForm extends ConfigFormBase  {
    */
   protected function getEditableConfigNames() {
     return [
-      'liveblog.notification_channel.settings',
+      'liveblog.notification_channel',
     ];
   }
 

--- a/src/NotificationChannel/NotificationChannelInterface.php
+++ b/src/NotificationChannel/NotificationChannelInterface.php
@@ -6,6 +6,7 @@ use Drupal\Component\Plugin\ConfigurablePluginInterface;
 use Drupal\Component\Plugin\PluginInspectionInterface;
 use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
+use Drupal\liveblog\Entity\LiveblogPost;
 
 /**
  * Interface for service plugin controllers.
@@ -13,5 +14,23 @@ use Drupal\Core\Plugin\PluginFormInterface;
  * @ingroup liveblog_notification_channel
  */
 interface NotificationChannelInterface extends PluginInspectionInterface, PluginFormInterface, ConfigurablePluginInterface, ContainerFactoryPluginInterface {
+
+  /**
+   * Gets the notification channel client.
+   *
+   * @return mixed
+   *   The notification channel client.
+   */
+  public function getClient();
+
+  /**
+   * Triggers event notification connected to the liveblog post.
+   *
+   * @param \Drupal\liveblog\Entity\LiveblogPost $liveblogPost
+   *   The target liveblog post.
+   * @param string $event
+   *   The event name.
+   */
+  public function triggerLiveblogPostEvent(LiveblogPost $liveblogPost, $event);
 
 }

--- a/src/NotificationChannel/NotificationChannelInterface.php
+++ b/src/NotificationChannel/NotificationChannelInterface.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace Drupal\liveblog\NotificationChannel;
+
+use Drupal\Component\Plugin\PluginInspectionInterface;
+use Drupal\Core\Plugin\PluginFormInterface;
+
+/**
+ * Interface for service plugin controllers.
+ *
+ * @ingroup liveblog_notification_channel
+ */
+interface NotificationChannelInterface extends PluginInspectionInterface, PluginFormInterface  {
+
+}

--- a/src/NotificationChannel/NotificationChannelInterface.php
+++ b/src/NotificationChannel/NotificationChannelInterface.php
@@ -2,7 +2,9 @@
 
 namespace Drupal\liveblog\NotificationChannel;
 
+use Drupal\Component\Plugin\ConfigurablePluginInterface;
 use Drupal\Component\Plugin\PluginInspectionInterface;
+use Drupal\Core\Plugin\ContainerFactoryPluginInterface;
 use Drupal\Core\Plugin\PluginFormInterface;
 
 /**
@@ -10,6 +12,6 @@ use Drupal\Core\Plugin\PluginFormInterface;
  *
  * @ingroup liveblog_notification_channel
  */
-interface NotificationChannelInterface extends PluginInspectionInterface, PluginFormInterface  {
+interface NotificationChannelInterface extends PluginInspectionInterface, PluginFormInterface, ConfigurablePluginInterface, ContainerFactoryPluginInterface {
 
 }

--- a/src/NotificationChannel/NotificationChannelInterface.php
+++ b/src/NotificationChannel/NotificationChannelInterface.php
@@ -26,11 +26,11 @@ interface NotificationChannelInterface extends PluginInspectionInterface, Plugin
   /**
    * Triggers event notification connected to the liveblog post.
    *
-   * @param \Drupal\liveblog\Entity\LiveblogPost $liveblogPost
+   * @param \Drupal\liveblog\Entity\LiveblogPost $liveblog_post
    *   The target liveblog post.
    * @param string $event
    *   The event name.
    */
-  public function triggerLiveblogPostEvent(LiveblogPost $liveblogPost, $event);
+  public function triggerLiveblogPostEvent(LiveblogPost $liveblog_post, $event);
 
 }

--- a/src/NotificationChannel/NotificationChannelManager.php
+++ b/src/NotificationChannel/NotificationChannelManager.php
@@ -66,7 +66,7 @@ class NotificationChannelManager extends DefaultPluginManager {
    *   Array of plugin labels, keyed by the plugin id.
    */
   public function getLabels() {
-    $list = array();
+    $list = [];
     foreach ($this->getDefinitions() as $plugin => $definition) {
       $list[$plugin] = $definition['label'];
     }

--- a/src/NotificationChannel/NotificationChannelManager.php
+++ b/src/NotificationChannel/NotificationChannelManager.php
@@ -1,0 +1,58 @@
+<?php
+
+namespace Drupal\liveblog\NotificationChannel;
+
+use Drupal\Core\Cache\CacheBackendInterface;
+use Drupal\Core\Extension\ModuleHandlerInterface;
+use Drupal\Core\Plugin\DefaultPluginManager;
+use Drupal\Core\Plugin\Factory\ContainerFactory;
+
+/**
+ * Provides an Liveblog Notification Channel plugin manager.
+ *
+ * @see \Drupal\liveblog\NotificationChannel\NotificationChannelInterface
+ * @see plugin_api
+ *
+ * @ingroup liveblog_notification_channel
+ */
+class NotificationChannelManager extends DefaultPluginManager {
+
+  /**
+   * Constructs a NotificationChannelManager object.
+   *
+   * @param \Traversable $namespaces
+   *   An object that implements \Traversable which contains the root paths
+   *   keyed by the corresponding namespace to look for plugin implementations.
+   * @param \Drupal\Core\Cache\CacheBackendInterface $cache_backend
+   *   Cache backend instance to use.
+   * @param \Drupal\Core\Extension\ModuleHandlerInterface $module_handler
+   *   The module handler to invoke the alter hook with.
+   */
+  public function __construct(\Traversable $namespaces, CacheBackendInterface $cache_backend, ModuleHandlerInterface $module_handler) {
+    parent::__construct(
+      'Plugin/LiveblogNotificationChannel',
+      $namespaces,
+      $module_handler,
+      'Drupal\liveblog\NotificationChannel\NotificationChannelInterface',
+      'Drupal\liveblog\Annotation\LiveblogNotificationChannel'
+    );
+    $this->alterInfo('liveblog_notification_channel_info');
+    $this->setCacheBackend($cache_backend, 'liveblog_notification_channel_info_plugins');
+    $this->factory = new ContainerFactory($this, '\Drupal\liveblog\NotificationChannel\NotificationChannelInterface');
+  }
+
+  /**
+   * Returns the plugin labels.
+   *
+   * @return string[]
+   *   Array of plugin labels, keyed by the plugin id.
+   */
+  public function getLabels() {
+    $list = array();
+    foreach ($this->getDefinitions() as $plugin => $definition) {
+      $list[$plugin] = $definition['label'];
+    }
+    return $list;
+  }
+
+}

--- a/src/NotificationChannel/NotificationChannelManager.php
+++ b/src/NotificationChannel/NotificationChannelManager.php
@@ -56,7 +56,7 @@ class NotificationChannelManager extends DefaultPluginManager {
     $this->alterInfo('liveblog_notification_channel_info');
     $this->setCacheBackend($cache_backend, 'liveblog_notification_channel_info_plugins');
     $this->factory = new ContainerFactory($this, '\Drupal\liveblog\NotificationChannel\NotificationChannelInterface');
-    $this->config = $config_factory->get('liveblog.notification_channel.settings');
+    $this->config = $config_factory->get('liveblog.notification_channel');
   }
 
   /**

--- a/src/NotificationChannel/NotificationChannelPluginBase.php
+++ b/src/NotificationChannel/NotificationChannelPluginBase.php
@@ -1,0 +1,36 @@
+<?php
+
+namespace Drupal\liveblog\NotificationChannel;
+
+use Drupal\Component\Plugin\PluginBase;
+use Drupal\Core\Form\FormStateInterface;
+
+/**
+ * Default controller class for service plugins.
+ *
+ * @ingroup liveblog_notification_channel
+ */
+abstract class NotificationChannelPluginBase extends PluginBase implements NotificationChannelInterface  {
+
+  /**
+   * {@inheritdoc}
+   */
+  public function buildConfigurationForm(array $form, FormStateInterface $form_state) {
+    // Nothing to do here by default.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
+    // Nothing to do here by default.
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
+    // Nothing to do here by default.
+  }
+
+}

--- a/src/NotificationChannel/NotificationChannelPluginBase.php
+++ b/src/NotificationChannel/NotificationChannelPluginBase.php
@@ -4,6 +4,7 @@ namespace Drupal\liveblog\NotificationChannel;
 
 use Drupal\Component\Plugin\PluginBase;
 use Drupal\Core\Config\ConfigFactoryInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 
@@ -22,6 +23,13 @@ abstract class NotificationChannelPluginBase extends PluginBase implements Notif
   protected $configFactory;
 
   /**
+   * The entity type manager.
+   *
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
+   */
+  protected $entityTypeManager;
+
+  /**
    * Constructs an EntityForm object.
    *
    * @param array $configuration
@@ -33,9 +41,10 @@ abstract class NotificationChannelPluginBase extends PluginBase implements Notif
    * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
    *   The factory for configuration objects.
    */
-  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config_factory) {
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config_factory, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition);
     $this->configFactory = $config_factory;
+    $this->entityTypeManager = $entity_type_manager;
     $this->configuration += $this->defaultConfiguration();
   }
 
@@ -47,7 +56,8 @@ abstract class NotificationChannelPluginBase extends PluginBase implements Notif
       $configuration,
       $plugin_id,
       $plugin_definition,
-      $container->get('config.factory')
+      $container->get('config.factory'),
+      $container->get('entity_type.manager')
     );
   }
 

--- a/src/NotificationChannel/NotificationChannelPluginBase.php
+++ b/src/NotificationChannel/NotificationChannelPluginBase.php
@@ -142,7 +142,7 @@ abstract class NotificationChannelPluginBase extends PluginBase implements Notif
    * {@inheritdoc}
    */
   public function calculateDependencies() {
-    return array();
+    return [];
   }
 
 }

--- a/src/NotificationChannel/NotificationChannelPluginBase.php
+++ b/src/NotificationChannel/NotificationChannelPluginBase.php
@@ -3,14 +3,96 @@
 namespace Drupal\liveblog\NotificationChannel;
 
 use Drupal\Component\Plugin\PluginBase;
+use Drupal\Core\Config\ConfigFactoryInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
 
 /**
  * Default controller class for service plugins.
  *
  * @ingroup liveblog_notification_channel
  */
-abstract class NotificationChannelPluginBase extends PluginBase implements NotificationChannelInterface  {
+abstract class NotificationChannelPluginBase extends PluginBase implements NotificationChannelInterface {
+
+  /**
+   * The config factory.
+   *
+   * @var \Drupal\Core\Config\ConfigFactoryInterface
+   */
+  protected $configFactory;
+
+  /**
+   * Constructs an EntityForm object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param \Drupal\Core\Config\ConfigFactoryInterface $config_factory
+   *   The factory for configuration objects.
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, ConfigFactoryInterface $config_factory) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition);
+    $this->configFactory = $config_factory;
+    $this->configuration += $this->defaultConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->get('config.factory')
+    );
+  }
+
+  /**
+   * Gets name of the config setting.
+   *
+   * @return string
+   *   Name of the config setting.
+   */
+  protected function getConfigName() {
+    return 'liveblog.notification_channel.' . $this->getPluginId();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function defaultConfiguration() {
+    $config = $this->configFactory->get($this->getConfigName());
+    return $config->getRawData();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function getConfiguration() {
+    return $this->configuration;
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function setConfiguration(array $configuration) {
+    $this->configuration = $configuration;
+  }
+
+  /**
+   * Saves the notification channel configuration.
+   */
+  protected function saveConfiguration() {
+    $config = $this->configFactory->getEditable($this->getConfigName());
+    foreach ($this->getConfiguration() as $key => $value) {
+      $config->set($key, $value);
+    }
+    $config->save();
+  }
 
   /**
    * {@inheritdoc}
@@ -30,7 +112,15 @@ abstract class NotificationChannelPluginBase extends PluginBase implements Notif
    * {@inheritdoc}
    */
   public function submitConfigurationForm(array &$form, FormStateInterface $form_state) {
-    // Nothing to do here by default.
+    $this->configuration = $form_state->getValue('plugin_settings');
+    $this->saveConfiguration();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function calculateDependencies() {
+    return array();
   }
 
 }

--- a/src/NotificationChannel/NotificationChannelPluginBase.php
+++ b/src/NotificationChannel/NotificationChannelPluginBase.php
@@ -77,6 +77,18 @@ abstract class NotificationChannelPluginBase extends PluginBase implements Notif
   }
 
   /**
+   * Gets configuration value of a single variable.
+   *
+   * @param string $name
+   *   The variable name.
+   * @return mixed
+   *   The variable value, null if not set.
+   */
+  public function getConfigurationValue($name) {
+    return isset($this->configuration[$name]) ? $this->configuration[$name] : NULL;
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function setConfiguration(array $configuration) {

--- a/src/Plugin/Field/FieldWidget/TaxonomyTreeWidget.php
+++ b/src/Plugin/Field/FieldWidget/TaxonomyTreeWidget.php
@@ -66,12 +66,12 @@ class TaxonomyTreeWidget extends OptionsWidgetBase {
         '#attributes' => ['class' => ['field--widget-liveblog-taxonomy-tree--node']],
       ];
 
-      $element[$item['value']]['element'] = array(
+      $element[$item['value']]['element'] = [
         '#type' => 'checkbox',
         '#title' => $item['title'],
         '#default_value' => in_array($item['value'], $selected) ? TRUE : FALSE,
         '#attributes' => ['class' => ['field--widget-liveblog-taxonomy-tree--item']],
-      );
+      ];
 
       if (!empty($item['children'])) {
         $element[$item['value']]['children'] = $this->prepareTreeElements($item['children'], $selected);
@@ -94,7 +94,7 @@ class TaxonomyTreeWidget extends OptionsWidgetBase {
    *   Mapped options tree.
    */
   protected function mapTree(array &$data, $level = 0) {
-    $tree = array();
+    $tree = [];
 
     $get_level = function($a) {
       $level = 0;


### PR DESCRIPTION
Configure ws server on pusher.com.
Integrate ws server as a pluggable notification channel.
Add a setting for a notification channel plugin.
We should load correct js files(library). Frontend will be also pluggable.
Provide a default notification channel plugin
reloads page after a while in frontend.(frontend)
Create a pusher plugin
Implement notifications via the pusher API. 
We do not spread edit, delete events, only new posts.
