### PR TITLE
KUR-41: Thunder Liveblogging: Post creation / editing form

### DIFF
--- a/config/install/core.entity_form_display.node.liveblog.default.yml
+++ b/config/install/core.entity_form_display.node.liveblog.default.yml
@@ -4,9 +4,12 @@ dependencies:
   config:
     - field.field.node.liveblog.body
     - field.field.node.liveblog.field_highlights
+    - field.field.node.liveblog.field_posts_load_limit
+    - field.field.node.liveblog.field_posts_number_initial
     - field.field.node.liveblog.field_status
     - node.type.liveblog
   module:
+    - liveblog
     - path
     - scheduler
     - text
@@ -33,6 +36,18 @@ content:
     settings: {  }
     third_party_settings: {  }
     type: liveblog_taxonomy_tree
+  field_posts_load_limit:
+    weight: 27
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
+  field_posts_number_initial:
+    weight: 26
+    settings:
+      placeholder: ''
+    third_party_settings: {  }
+    type: number
   field_status:
     weight: 10
     settings:

--- a/config/install/core.entity_view_display.node.liveblog.default.yml
+++ b/config/install/core.entity_view_display.node.liveblog.default.yml
@@ -1,10 +1,11 @@
-uuid: 7feccaff-7331-49f2-afc9-a6dc5d7d101a
 langcode: en
 status: true
 dependencies:
   config:
     - field.field.node.liveblog.body
     - field.field.node.liveblog.field_highlights
+    - field.field.node.liveblog.field_posts_load_limit
+    - field.field.node.liveblog.field_posts_number_initial
     - field.field.node.liveblog.field_status
     - node.type.liveblog
   module:
@@ -35,9 +36,11 @@ content:
     settings: {  }
     third_party_settings: {  }
   liveblog_posts:
-    weight: 4
+    weight: 3
     settings: {  }
     third_party_settings: {  }
 hidden:
   field_highlights: true
+  field_posts_load_limit: true
+  field_posts_number_initial: true
   langcode: true

--- a/config/install/core.entity_view_display.node.liveblog.teaser.yml
+++ b/config/install/core.entity_view_display.node.liveblog.teaser.yml
@@ -5,6 +5,8 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.liveblog.body
     - field.field.node.liveblog.field_highlights
+    - field.field.node.liveblog.field_posts_load_limit
+    - field.field.node.liveblog.field_posts_number_initial
     - field.field.node.liveblog.field_status
     - node.type.liveblog
   module:
@@ -37,5 +39,7 @@ content:
     third_party_settings: {  }
 hidden:
   field_highlights: true
+  field_posts_load_limit: true
+  field_posts_number_initial: true
   langcode: true
   liveblog_posts: true

--- a/config/install/field.field.node.liveblog.field_posts_load_limit.yml
+++ b/config/install/field.field.node.liveblog.field_posts_load_limit.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_posts_load_limit
+    - node.type.liveblog
+id: node.liveblog.field_posts_load_limit
+field_name: field_posts_load_limit
+entity_type: node
+bundle: liveblog
+label: 'Load limit for posts'
+description: 'How many posts should be loaded during infinite scrolling.'
+required: true
+translatable: false
+default_value:
+  -
+    value: 5
+default_value_callback: ''
+settings:
+  min: 1
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/install/field.field.node.liveblog.field_posts_number_initial.yml
+++ b/config/install/field.field.node.liveblog.field_posts_number_initial.yml
@@ -1,0 +1,24 @@
+langcode: en
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_posts_number_initial
+    - node.type.liveblog
+id: node.liveblog.field_posts_number_initial
+field_name: field_posts_number_initial
+entity_type: node
+bundle: liveblog
+label: 'Initial number of posts'
+description: 'Initial number of posts when the page is loaded for the first time.'
+required: true
+translatable: false
+default_value:
+  -
+    value: 10
+default_value_callback: ''
+settings:
+  min: 1
+  max: null
+  prefix: ''
+  suffix: ''
+field_type: integer

--- a/config/install/field.storage.node.field_posts_load_limit.yml
+++ b/config/install/field.storage.node.field_posts_load_limit.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_posts_load_limit
+field_name: field_posts_load_limit
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/field.storage.node.field_posts_number_initial.yml
+++ b/config/install/field.storage.node.field_posts_number_initial.yml
@@ -1,0 +1,19 @@
+langcode: en
+status: true
+dependencies:
+  module:
+    - node
+id: node.field_posts_number_initial
+field_name: field_posts_number_initial
+entity_type: node
+type: integer
+settings:
+  unsigned: false
+  size: normal
+module: core
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/config/install/views.view.liveblog_posts.yml
+++ b/config/install/views.view.liveblog_posts.yml
@@ -1284,6 +1284,48 @@ display:
           entity_type: node
           entity_field: title
           plugin_id: string
+        status:
+          id: status
+          table: liveblog_post
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: true
+          expose:
+            operator_id: ''
+            label: 'Published status'
+            description: ''
+            use_operator: false
+            operator: status_op
+            identifier: status
+            required: true
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+              anonymous: '0'
+              editor: '0'
+              seo: '0'
+              administrator: '0'
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: liveblog_post
+          entity_field: status
+          plugin_id: boolean
       sorts:
         created:
           id: created

--- a/config/install/views.view.liveblog_posts_rest.yml
+++ b/config/install/views.view.liveblog_posts_rest.yml
@@ -969,6 +969,44 @@ display:
           entity_type: liveblog_post
           entity_field: created
           plugin_id: date
+        status:
+          id: status
+          table: liveblog_post
+          field: status
+          relationship: none
+          group_type: group
+          admin_label: ''
+          operator: '='
+          value: '1'
+          group: 1
+          exposed: false
+          expose:
+            operator_id: ''
+            label: ''
+            description: ''
+            use_operator: false
+            operator: ''
+            identifier: ''
+            required: false
+            remember: false
+            multiple: false
+            remember_roles:
+              authenticated: authenticated
+          is_grouped: false
+          group_info:
+            label: ''
+            description: ''
+            identifier: ''
+            optional: true
+            widget: select
+            multiple: false
+            remember: false
+            default_group: All
+            default_group_multiple: {  }
+            group_items: {  }
+          entity_type: liveblog_post
+          entity_field: status
+          plugin_id: boolean
       sorts:
         created:
           id: created
@@ -1055,37 +1093,6 @@ display:
         - 'url.query_args:sort_by'
         - 'url.query_args:sort_order'
         - user
-      tags:
-        - 'config:core.entity_view_display.liveblog_post.liveblog_post.default'
-  # @todo Remove the 'related_posts_page' display in future. It was created only
-  # for convinient discovery of get parameters in the 'related_posts_rest'
-  # display.
-  related_posts_page:
-    display_plugin: page
-    id: related_posts_page
-    display_title: 'Related Posts (Page)'
-    position: 2
-    display_options:
-      display_extenders: {  }
-      path: node/%node/posts
-      access:
-        type: perm
-        options:
-          perm: 'edit liveblog_post entity'
-      defaults:
-        access: false
-      display_description: ''
-    cache_metadata:
-      max-age: -1
-      contexts:
-        - 'languages:language_content'
-        - 'languages:language_interface'
-        - url
-        - url.query_args
-        - 'url.query_args:sort_by'
-        - 'url.query_args:sort_order'
-        - user
-        - user.permissions
       tags:
         - 'config:core.entity_view_display.liveblog_post.liveblog_post.default'
   related_posts_rest:

--- a/liveblog.module
+++ b/liveblog.module
@@ -121,16 +121,29 @@ function template_preprocess_liveblog_posts(&$variables) {
 function liveblog_post_get_highlight_options(FieldStorageDefinitionInterface $definition, FieldableEntityInterface $entity = NULL, &$cacheable = NULL) {
   $options = [];
 
-  // @todo: get terms from liveblog. hook_entity_prepare_form
-  $ids = \Drupal::entityQuery('taxonomy_term')
-    ->condition('vid', 'highlights')
-    ->execute();
+  // Get the liveblog node from the URL.
+  $node = \Drupal::request()->attributes->get('node');
+
+  // Get terms from the liveblog node, if we are at the liveblog page.
+  if ($node && $node->getType() == 'liveblog') {
+    $ids = [];
+    foreach ($node->field_highlights as $highlight) {
+      $ids[] = $highlight->target_id;
+    }
+  }
+  else {
+    // Fallback to all the highlight terms.
+    $ids = \Drupal::entityQuery('taxonomy_term')
+      ->condition('vid', 'highlights')
+      ->execute();
+  }
+
   if (!empty($ids)) {
     $terms = Term::loadMultiple($ids);
     foreach ($terms as $term) {
       $name = $term->name->value;
-      // Convert term name to a machine name, which will be used as a CSS
-      // class in templates.
+      // Convert term name to a machine name, which will be used as a CSS class
+      // in templates.
       $key = strtolower(Html::cleanCssIdentifier($name));
       $options[$key] = $name;
     }

--- a/liveblog.module
+++ b/liveblog.module
@@ -92,7 +92,12 @@ function template_preprocess_liveblog_posts(&$variables) {
         ->getFormObject('liveblog_post', 'add')
         ->setEntity($entity);
       $form = \Drupal::formBuilder()->getForm($form_object);
-      $variables['form'] = $form;
+      $variables['form_wrapper'] = array(
+        '#type' => 'details',
+        '#title' => t('Create liveblog post'),
+        '#open' => TRUE,
+      );
+      $variables['form_wrapper']['form'] = $form;
     }
   }
   else {

--- a/liveblog.module
+++ b/liveblog.module
@@ -65,12 +65,26 @@ function template_preprocess_liveblog_post(&$variables) {
 function template_preprocess_liveblog_posts(&$variables) {
   /* @var $node Drupal\node\Entity\Node */
   $node = $variables['node'];
-  // Render related posts.
+
   if ($node->field_status->value) {
+    // Embed related posts of the active liveblog.
     $views_content = views_embed_view('liveblog_posts', 'liveblog_posts', $node->id());
+
+    $account = \Drupal::currentUser();
+    // Embed liveblog post add form.
+    if ($account->hasPermission('add liveblog_post entity')) {
+      $entity = \Drupal::entityTypeManager()->getStorage('liveblog_post')->create([]);
+      $form_object = \Drupal::entityTypeManager()
+        ->getFormObject('liveblog_post', 'add')
+        ->setEntity($entity);
+      $form = \Drupal::formBuilder()->getForm($form_object);
+      $variables['form'] = $form;
+    }
   }
   else {
+    // Embed archive of related posts if the liveblog is not active anymore.
     $views_content = views_embed_view('liveblog_posts', 'liveblog_posts_archive', $node->id());
   }
+  // Embed liveblog posts views.
   $variables['posts'] = \Drupal::service('renderer')->render($views_content);
 }

--- a/liveblog.module
+++ b/liveblog.module
@@ -92,12 +92,12 @@ function template_preprocess_liveblog_posts(&$variables) {
         ->getFormObject('liveblog_post', 'add')
         ->setEntity($entity);
       $form = \Drupal::formBuilder()->getForm($form_object);
-      $variables['form_wrapper'] = array(
+      $variables['form'] = array(
         '#type' => 'details',
         '#title' => t('Create liveblog post'),
         '#open' => TRUE,
       );
-      $variables['form_wrapper']['form'] = $form;
+      $variables['form'][] = $form;
     }
   }
   else {

--- a/liveblog.module
+++ b/liveblog.module
@@ -30,9 +30,11 @@ function liveblog_entity_extra_field_info() {
  */
 function liveblog_node_view(array &$build, Node $node, EntityViewDisplayInterface $display) {
   if ($display->getComponent('liveblog_posts')) {
+    $initial_number = $node->field_posts_number_initial->value;
+    $load_more_number = $node->field_posts_load_limit->value;
     $javascriptSettings = [
-      'getURL'      => '/liveblog/' . $node->id() . '/posts?items_per_page=2',
-      'getNextURL'  => '/liveblog/' . $node->id() . '/posts?items_per_page=1&created_op=<&created[value]=@%s',
+      'getURL'      => '/liveblog/' . $node->id() . '/posts?items_per_page=' . $initial_number,
+      'getNextURL'  => '/liveblog/' . $node->id() . '/posts?items_per_page=' . $load_more_number . '&created_op=<&created[value]=@%s',
     ];
     $build['liveblog_posts'] = [
       '#theme' => 'liveblog_posts',

--- a/src/Form/LiveblogPostForm.php
+++ b/src/Form/LiveblogPostForm.php
@@ -94,6 +94,17 @@ class LiveblogPostForm extends ContentEntityForm {
       $form['actions']['submit']['#value'] = t('Update');
     }
 
+    // Hide status, source, location fields in a collapsible wrapper.
+    $form['additional'] = array(
+      '#type' => 'details',
+      '#title' => t('Additional'),
+      '#weight' => 20,
+    );
+    foreach (['status', 'source', 'location'] as $key) {
+      $form['additional'][$key] = $form[$key];
+      unset($form[$key]);
+    }
+
     return $form;
   }
 

--- a/src/Form/LiveblogPostForm.php
+++ b/src/Form/LiveblogPostForm.php
@@ -97,16 +97,6 @@ class LiveblogPostForm extends ContentEntityForm {
    */
   public function ajaxRebuildCallback(array $form, FormStateInterface $form_state) {
     drupal_set_message(t('Liveblog post was successfully created'));
-
-    // @todo Clear form values.
-    //$form_state->setRebuild(TRUE);
-    //$form_state->setValues([]);
-    /*$entity = \Drupal::entityTypeManager()->getStorage('liveblog_post')->create([]);
-    $form_object = \Drupal::entityTypeManager()
-      ->getFormObject('liveblog_post', 'add')
-      ->setEntity($entity);*/
-    //$new_form_state = new FormState();
-    //$form = \Drupal::formBuilder()->rebuildForm($this->getFormId(), $form_state);
     return $form;
   }
 
@@ -138,6 +128,43 @@ class LiveblogPostForm extends ContentEntityForm {
       // Redirect to the post's full page if we are not at the liveblog page.
       $form_state->setRedirect($url->getRouteName(), $url->getRouteParameters());
     }
+    else {
+      // Clear form input, as we stay on the same page.
+      $this->clearFormInput($form, $form_state);
+    }
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public function submitForm(array &$form, FormStateInterface $form_state) {
+    parent::submitForm($form, $form_state);
+  }
+
+  /**
+   * Clears form input.
+   *
+   * @param array $form
+   *   The form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The form state.
+   */
+  protected function clearFormInput(array $form, FormStateInterface $form_state) {
+    // Replace the form entity with an empty instance.
+    $this->entity = $this->entityTypeManager->getStorage('liveblog_post')->create([]);
+    // Clear user input.
+    $input = $form_state->getUserInput();
+    // We should not clear the system items from the user input.
+    $clean_keys = $form_state->getCleanValueKeys();
+    $clean_keys[] = 'ajax_page_state';
+    foreach ($input as $key => $item) {
+      if (!in_array($key, $clean_keys) && substr($key, 0, 1) !== '_') {
+        unset($input[$key]);
+      }
+    }
+    $form_state->setUserInput($input);
+    // Rebuild the form state values.
+    $form_state->setRebuild();
   }
 
 }

--- a/src/Form/LiveblogPostForm.php
+++ b/src/Form/LiveblogPostForm.php
@@ -3,8 +3,10 @@
 namespace Drupal\liveblog\Form;
 
 use Drupal\Core\Entity\ContentEntityForm;
-use Drupal\Core\Language\Language;
+use Drupal\Core\Entity\EntityManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 
 /**
  * Form controller for the liveblog_post entity edit forms.
@@ -14,16 +16,79 @@ use Drupal\Core\Form\FormStateInterface;
 class LiveblogPostForm extends ContentEntityForm {
 
   /**
+   * The current request.
+   *
+   * @var \Symfony\Component\HttpFoundation\Request
+   */
+  protected $request;
+
+  /**
+   * Constructs a ContentEntityForm object.
+   *
+   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
+   *   The entity manager.
+   * @param \Symfony\Component\HttpFoundation\RequestStack
+   *   The current request.
+   */
+  public function __construct(EntityManagerInterface $entity_manager, RequestStack $request_stack) {
+    parent::__construct($entity_manager);
+    $this->request = $request_stack->getCurrentRequest();
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container) {
+    return new static(
+      $container->get('entity.manager'),
+      $container->get('request_stack')
+    );
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function buildForm(array $form, FormStateInterface $form_state) {
     /* @var $entity \Drupal\liveblog\Entity\LiveblogPost */
-    $form = parent::buildForm($form, $form_state);
     $entity = $this->entity;
+    if ($node = $this->getCurrentLiveblogNode()) {
+      // Pre-populate liveblog reference if we are at the liveblog page.
+      $entity->setLiveblog($node);
+    }
 
-    // @todo Implement ajax logic here.
+    $form = parent::buildForm($form, $form_state);
+
+    if ($node) {
+      // Hide author and liveblog fields, as they are already pre-populated and
+      // should not be changed.
+      $form['uid']['#access'] = FALSE;
+      $form['liveblog']['#access'] = FALSE;
+    }
+
+    if ($entity->isNew()) {
+      $form['actions']['submit']['#value'] = t('Create');
+    }
+    else {
+      $form['actions']['submit']['#value'] = t('Update');
+    }
 
     return $form;
+  }
+
+  /**
+   * Gets liveblog node from the current request.
+   *
+   * Gets the liveblog node from the request if we are at the liveblog page.
+   *
+   * @return \Drupal\node\Entity\Node|null
+   *   The liveblog node, null if not found.
+   */
+  protected function getCurrentLiveblogNode() {
+    /* @var \Drupal\node\Entity\Node $node */
+    $node = $this->request->attributes->get('node');
+    if ($node && $node->getType() == 'liveblog') {
+      return $node;
+    }
   }
 
   /**
@@ -34,8 +99,10 @@ class LiveblogPostForm extends ContentEntityForm {
     $entity->save();
     $url = $entity->toUrl();
 
-    // Redirect to the post's full page.
-    $form_state->setRedirect($url->getRouteName(), $url->getRouteParameters());
+    if (!$this->getCurrentLiveblogNode()) {
+      // Redirect to the post's full page if we are not at the liveblog page.
+      $form_state->setRedirect($url->getRouteName(), $url->getRouteParameters());
+    }
   }
 
 }

--- a/src/Form/LiveblogPostForm.php
+++ b/src/Form/LiveblogPostForm.php
@@ -3,7 +3,7 @@
 namespace Drupal\liveblog\Form;
 
 use Drupal\Core\Entity\ContentEntityForm;
-use Drupal\Core\Entity\EntityManagerInterface;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
 use Drupal\Core\Form\FormStateInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\RequestStack;
@@ -25,12 +25,12 @@ class LiveblogPostForm extends ContentEntityForm {
   /**
    * Constructs a ContentEntityForm object.
    *
-   * @param \Drupal\Core\Entity\EntityManagerInterface $entity_manager
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_manager
    *   The entity manager.
    * @param \Symfony\Component\HttpFoundation\RequestStack
    *   The current request.
    */
-  public function __construct(EntityManagerInterface $entity_manager, RequestStack $request_stack) {
+  public function __construct(EntityTypeManagerInterface $entity_manager, RequestStack $request_stack) {
     parent::__construct($entity_manager);
     $this->request = $request_stack->getCurrentRequest();
   }
@@ -59,10 +59,19 @@ class LiveblogPostForm extends ContentEntityForm {
     $form = parent::buildForm($form, $form_state);
 
     if ($node) {
+      $form['#prefix'] = "<div id=\"{$this->getFormId()}-wrapper\">";
+      $form['#suffix'] = '</div>';
+
       // Hide author and liveblog fields, as they are already pre-populated and
       // should not be changed.
       $form['uid']['#access'] = FALSE;
       $form['liveblog']['#access'] = FALSE;
+
+      $form['actions']['submit']['#ajax'] = [
+        'wrapper' => $this->getFormId() . '-wrapper',
+        'callback' => array($this, 'ajaxRebuildCallback'),
+        'effect' => 'fade',
+      ];
     }
 
     if ($entity->isNew()) {
@@ -72,6 +81,32 @@ class LiveblogPostForm extends ContentEntityForm {
       $form['actions']['submit']['#value'] = t('Update');
     }
 
+    return $form;
+  }
+
+  /**
+   * Callback for ajax form submission.
+   *
+   * @param array $form
+   *   An associative array containing the structure of the form.
+   * @param \Drupal\Core\Form\FormStateInterface $form_state
+   *   The current state of the form.
+   *
+   * @return array
+   *   The rebuilt form.
+   */
+  public function ajaxRebuildCallback(array $form, FormStateInterface $form_state) {
+    drupal_set_message(t('Liveblog post was successfully created'));
+
+    // @todo Clear form values.
+    //$form_state->setRebuild(TRUE);
+    //$form_state->setValues([]);
+    /*$entity = \Drupal::entityTypeManager()->getStorage('liveblog_post')->create([]);
+    $form_object = \Drupal::entityTypeManager()
+      ->getFormObject('liveblog_post', 'add')
+      ->setEntity($entity);*/
+    //$new_form_state = new FormState();
+    //$form = \Drupal::formBuilder()->rebuildForm($this->getFormId(), $form_state);
     return $form;
   }
 
@@ -97,9 +132,9 @@ class LiveblogPostForm extends ContentEntityForm {
   public function save(array $form, FormStateInterface $form_state) {
     $entity = $this->getEntity();
     $entity->save();
-    $url = $entity->toUrl();
 
     if (!$this->getCurrentLiveblogNode()) {
+      $url = $entity->toUrl();
       // Redirect to the post's full page if we are not at the liveblog page.
       $form_state->setRedirect($url->getRouteName(), $url->getRouteParameters());
     }

--- a/src/Plugin/rest/resource/LiveblogPostFormResource.php
+++ b/src/Plugin/rest/resource/LiveblogPostFormResource.php
@@ -24,11 +24,11 @@ use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 class LiveblogPostFormResource extends ResourceBase {
 
   /**
-   * The entity type targeted by this resource.
+   * The entity type manager.
    *
-   * @var \Drupal\Core\Entity\EntityStorageInterface
+   * @var \Drupal\Core\Entity\EntityTypeManagerInterface
    */
-  protected $entityStorage;
+  protected $entityTypeManager;
 
   /**
    * Constructs a Drupal\rest\Plugin\ResourceBase object.
@@ -48,7 +48,7 @@ class LiveblogPostFormResource extends ResourceBase {
    */
   public function __construct(array $configuration, $plugin_id, $plugin_definition, array $serializer_formats, LoggerInterface $logger, EntityTypeManagerInterface $entity_type_manager) {
     parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger);
-    $this->entityStorage = $entity_type_manager->getStorage('liveblog_post');
+    $this->entityTypeManager = $entity_type_manager;
   }
 
   /**
@@ -78,9 +78,9 @@ class LiveblogPostFormResource extends ResourceBase {
    */
   public function get($id = NULL) {
     if ($id) {
-      if ($entity = $this->entityStorage->load($id)) {
-        $form_object = \Drupal::entityTypeManager()
-          ->getFormObject('liveblog_post', 'add')
+      if ($entity = $this->entityTypeManager->getStorage('liveblog_post')->load($id)) {
+        $form_object = $this->entityTypeManager
+          ->getFormObject('liveblog_post', 'edit')
           ->setEntity($entity);
         $form = \Drupal::formBuilder()->getForm($form_object);
         $variables['form'] = $form;

--- a/src/Plugin/rest/resource/LiveblogPostFormResource.php
+++ b/src/Plugin/rest/resource/LiveblogPostFormResource.php
@@ -1,0 +1,99 @@
+<?php
+
+namespace Drupal\liveblog\Plugin\rest\resource;
+
+use Drupal\Core\Ajax\AjaxResponse;
+use Drupal\Core\Entity\EntityTypeManagerInterface;
+use Drupal\rest\Plugin\ResourceBase;
+use Psr\Log\LoggerInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Symfony\Component\HttpKernel\Exception\BadRequestHttpException;
+use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
+
+/**
+ * Provides a resource for liveblog post form.
+ *
+ * @RestResource(
+ *   id = "liveblog_post_form",
+ *   label = @Translation("Liveblog post form"),
+ *   uri_paths = {
+ *     "canonical" = "/liveblog_post/{id}/form"
+ *   }
+ * )
+ */
+class LiveblogPostFormResource extends ResourceBase {
+
+  /**
+   * The entity type targeted by this resource.
+   *
+   * @var \Drupal\Core\Entity\EntityStorageInterface
+   */
+  protected $entityStorage;
+
+  /**
+   * Constructs a Drupal\rest\Plugin\ResourceBase object.
+   *
+   * @param array $configuration
+   *   A configuration array containing information about the plugin instance.
+   * @param string $plugin_id
+   *   The plugin_id for the plugin instance.
+   * @param mixed $plugin_definition
+   *   The plugin implementation definition.
+   * @param array $serializer_formats
+   *   The available serialization formats.
+   * @param \Psr\Log\LoggerInterface $logger
+   *   A logger instance.
+   * @param \Drupal\Core\Entity\EntityTypeManagerInterface $entity_type_manager
+   *   The entity type manager
+   */
+  public function __construct(array $configuration, $plugin_id, $plugin_definition, array $serializer_formats, LoggerInterface $logger, EntityTypeManagerInterface $entity_type_manager) {
+    parent::__construct($configuration, $plugin_id, $plugin_definition, $serializer_formats, $logger);
+    $this->entityStorage = $entity_type_manager->getStorage('liveblog_post');
+  }
+
+  /**
+   * {@inheritdoc}
+   */
+  public static function create(ContainerInterface $container, array $configuration, $plugin_id, $plugin_definition) {
+    return new static(
+      $configuration,
+      $plugin_id,
+      $plugin_definition,
+      $container->getParameter('serializer.formats'),
+      $container->get('logger.factory')->get('rest'),
+      $container->get('entity_type.manager')
+    );
+  }
+
+  /**
+   * Returns a liveblog post form specified ID.
+   *
+   * @param int $id
+   *   ID of the liveblog post entity.
+   *
+   * @return \Drupal\Core\Ajax\AjaxResponse
+   *   The response containing the liveblog post form.
+   *
+   * @throws \Symfony\Component\HttpKernel\Exception\HttpException
+   */
+  public function get($id = NULL) {
+    if ($id) {
+      if ($entity = $this->entityStorage->load($id)) {
+        $form_object = \Drupal::entityTypeManager()
+          ->getFormObject('liveblog_post', 'add')
+          ->setEntity($entity);
+        $form = \Drupal::formBuilder()->getForm($form_object);
+        $variables['form'] = $form;
+        $response = [
+          'form' => render($form),
+        ];
+        return new AjaxResponse($response);
+      }
+
+      throw new NotFoundHttpException(t('Entity with ID @id was not found', array('@id' => $id)));
+    }
+
+    throw new BadRequestHttpException(t('No entity ID was provided'));
+  }
+
+}

--- a/templates/liveblog-posts.html.twig
+++ b/templates/liveblog-posts.html.twig
@@ -1,4 +1,5 @@
 <section class="liveblog-posts">
+  {{ form }}
   <h3 class="liveblog-posts--title">{{ 'Liveblog posts'|trans }}</h3>
   {{ posts }}
 </section>


### PR DESCRIPTION
Post create form:
-Form will be displayed on the liveblog page on top of all posts.
-Form will be loaded by Drupal and use Drupal ajax submission.
-Form has all the post’s fields + 2 buttons: preview, submit.
-Post preview click(other task):
--Ajax request to Drupal to preview a post. Drupal renders preview via Drupal ajax.
--No instant preview is supported right now.
--For the MVP, just rely on the preview button. Paragraphs already have a preview in the form.
-Post submit click:
--Drupal creates a post via ajax.
--Show success message.
--The new post will appear automatically as a Pusher notification (Will be implemented in KUR-29).
Post edit form
-A separate API endpoint is created to get the edit form HTML by post ID.
-When editor clicks the “edit” link on the post, edit form replaces the post (frontend part).
-Form is pre-populated with post fields.
-Post preview click(other task):
--Preview should work the same way as for the “Post create form”.
-Post submit click:
--Ajax callback
--Post will be updated.
--(frontend)Post edit form will be replaced with an HTML of an updated post via a Drupal ajax command. The frontend needs to implement the suiting ajax command for that.
When the editor deletes a post:
-Confirmation message is shown(frontend)
-Post deletion request in ajax (frontend)
-Post is removed from timeline (frontend)
-No pusher notification is sent.