### PR TITLE
Added pusher dependency.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,8 @@
   ],
   "require": {
     "drupal/core": "~8.1",
-    "drupal/simple_gmap": "~1.0 || ~8.1.0"
+    "drupal/simple_gmap": "~1.0 || ~8.1.0",
+    "pusher/pusher-php-server": "^2.2"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
Let's add the pusher dependency to the liveblog module if possible, so it can be used properly.

Otherwise liveblog_pusher should become its own module.