### PR TITLE
Try to load Pusher library from libraries folders, if not present.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ You have to register an account for it here: https://pusher.com/. Please note do
 the App ID, Key and Secret.  
 You also need the pusher library. See here for instructions: https://github.com/pusher/pusher-http-php
 
+If you are not using a composer workflow, you can download the library here: https://github.com/pusher/pusher-http-php/releases.  
+Extract it into your libraries folder (`libraries`, `sites/all/libraries` or `sites/<domain>/libraries`) and rename it to `pusher`.
+The library should contain the path `lib/Pusher.php`
+
 ### Installation
 1. Activate the _Liveblog_ and the _Liveblog Pusher_ modules.
     - optionally activate _Liveblog Paragraphs_ for a preconfigured 

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ the App ID, Key and Secret.
 You also need the pusher library. See here for instructions: https://github.com/pusher/pusher-http-php
 
 If you are not using a composer workflow, you can download the library here: https://github.com/pusher/pusher-http-php/releases.  
-Extract it into your libraries folder (`libraries`, `sites/all/libraries` or `sites/<domain>/libraries`) and rename it to `pusher`.
+Extract it into your libraries folder (`libraries` or `sites/<domain>/libraries`) and rename it to `pusher`.
 The library should contain the path `lib/Pusher.php`
 
 ### Installation

--- a/modules/liveblog_pusher/src/Plugin/LiveblogNotificationChannel/PusherNotificationChannel.php
+++ b/modules/liveblog_pusher/src/Plugin/LiveblogNotificationChannel/PusherNotificationChannel.php
@@ -107,10 +107,22 @@ class PusherNotificationChannel extends NotificationChannelPluginBase {
   }
 
   /**
+   * Try to load Pusher library, if it wasn't autoloaded.
+   */
+  private function loadPusherLibrary() {
+    if (!class_exists('\Pusher') && function_exists('libraries_get_path')) {
+      include_once (DRUPAL_ROOT.'/'.libraries_get_path('pusher') . '/lib/Pusher.php');
+    }
+  }
+
+  /**
    * {@inheritdoc}
    */
   public function validateConfigurationForm(array &$form, FormStateInterface $form_state) {
     parent::validateConfigurationForm($form, $form_state);
+
+    $this->loadPusherLibrary();
+
     // Check the required dependency on the Pusher library.
     if (!class_exists('\Pusher')) {
       $form_state->setErrorByName('plugin', t('The "\Pusher" class was not found. Please make sure you have included the <a href="https://github.com/pusher/pusher-http-php">Pusher PHP Library</a>.'));
@@ -125,6 +137,9 @@ class PusherNotificationChannel extends NotificationChannelPluginBase {
    */
   public function getClient() {
     if (!$this->client) {
+
+      $this->loadPusherLibrary();
+
       $options = [
         'encrypted' => true
       ];


### PR DESCRIPTION
This pull request will support non-composer workflows.
The library can be added to distributions, or included manually by copying it to the `sites/all/libraries` folder.