### PR TITLE
Use api to uninstall types, fields etc

### DIFF
--- a/liveblog.install
+++ b/liveblog.install
@@ -6,6 +6,8 @@
  */
 
 use Drupal\liveblog\Entity\LiveblogPost;
+use Drupal\node\Entity\NodeType;
+use Drupal\taxonomy\Entity\Vocabulary;
 
 /**
  * Implements hook_install().
@@ -54,31 +56,13 @@ function liveblog_uninstall() {
   $configFactory = \Drupal::configFactory();
   $logger = \Drupal::logger('liveblog');
 
+  NodeType::load('liveblog')->delete();
+  Vocabulary::load('highlights')->delete();
+
   $configs = [
-    'core.base_field_override.node.liveblog.promote',
-    'core.entity_form_display.liveblog_post.liveblog_post.default',
-    'core.entity_form_display.node.liveblog.default',
-    'core.entity_view_display.liveblog_post.liveblog_post.default',
-    'core.entity_view_display.node.liveblog.default',
-    'core.entity_view_display.node.liveblog.teaser',
-    'core.entity_view_mode.liveblog_post.full',
-    'field.field.node.liveblog.body',
-    'field.field.node.liveblog.field_highlights',
-    'field.field.node.liveblog.field_posts_load_limit',
-    'field.field.node.liveblog.field_posts_number_initial',
-    'field.field.node.liveblog.field_status',
-    'field.storage.node.field_highlights',
-    'field.storage.node.field_posts_load_limit',
-    'field.storage.node.field_posts_number_initial',
-    'field.storage.node.field_status',
-    'language.content_settings.node.liveblog',
-    'language.content_settings.taxonomy_term.highlights',
     'liveblog.liveblog_post.settings',
     'liveblog.settings',
-    'node.type.liveblog',
     'rest.resource.entity.liveblog_post',
-    'taxonomy.vocabulary.highlights',
-    'views.view.liveblog_posts',
   ];
 
   foreach ($configs as $config) {


### PR DESCRIPTION
It's cleaner to use the API to delete all the stuff, because it will resolve dependencies automatically and remove all the related stuff.