### PR TITLE
Update format of dependencies

### DIFF
--- a/liveblog.info.yml
+++ b/liveblog.info.yml
@@ -1,21 +1,21 @@
 name: Liveblog
-description: Liveblogging module for Drupal
+description: Liveblogging module for Drupal.
 type: module
 core: 8.x
 configure: liveblog.admin.settings
 dependencies:
-  - field
-  - hal
-  - language
-  - link
-  - menu_ui
-  - node
-  - options
-  - path
-  - rest
-  - serialization
-  - taxonomy
-  - text
-  - user
-  - simple_gmap
-  - views
+  - drupal:field
+  - drupal:hal
+  - drupal:language
+  - drupal:link
+  - drupal:menu_ui
+  - drupal:node
+  - drupal:options
+  - drupal:path
+  - drupal:rest
+  - drupal:serialization
+  - drupal:taxonomy
+  - drupal:text
+  - drupal:user
+  - simple_gmap:simple_gmap
+  - drupal:views

--- a/modules/liveblog_pusher/liveblog_pusher.info.yml
+++ b/modules/liveblog_pusher/liveblog_pusher.info.yml
@@ -1,6 +1,6 @@
 name: Liveblog Pusher
-description: Provides a liveblog notification channel via Pusher.com
+description: Provides a liveblog notification channel via Pusher.com.
 type: module
 core: 8.x
 dependencies:
-  - liveblog
+  - liveblog:liveblog


### PR DESCRIPTION
[(https://www.drupal.org/project/liveblog/issues/3029198)]

All dependencies must be prefixed by project name, So please <a href="https://www.drupal.org/docs/8/creating-custom-modules/let-drupal-8-know-about-your-module-with-an-infoyml-file">apply new {project}:{module} format for dependencies in info.yml file</a>
<p>It is supported since 8.0 and 7.40 Change Record: <a href="https://www.drupal.org/node/2299747">Project namespaces can now be added for module dependencies</a>, and is now a Best Practice <a href="https://www.drupal.org/project/drupal/issues/2798891">Define project dependencies in core module .info files</a>).</p><p>
It is useful for DrupalCi to download the right dependencies and Installation profiles to work well. So sooner is better.
Hope this helps.</p>

