### PR TITLE
Increase simple_gmap version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -9,7 +9,7 @@
   ],
   "require": {
     "drupal/core": "^8.7.7 || ^9",
-    "drupal/simple_gmap": "~1.0 || ~8.1.0",
+    "drupal/simple_gmap": "~2.0",
     "pusher/pusher-php-server": "^3.0.0"
   },
   "autoload": {


### PR DESCRIPTION
The simple_gmap module released 8.x-2.0 which is now the D9 compatible version. We should require that.

See https://www.drupal.org/project/simple_gmap/issues/3088320